### PR TITLE
make before_release trigger during release (and others)

### DIFF
--- a/lib/Dist/Zilla/Plugin/NextVersion/Semantic.pm
+++ b/lib/Dist/Zilla/Plugin/NextVersion/Semantic.pm
@@ -4,10 +4,14 @@ package Dist::Zilla::Plugin::NextVersion::Semantic;
 =head1 SYNOPSIS
 
     # in dist.ini
+
     [NextVersion::Semantic]
     major = MAJOR, API CHANGE
     minor = MINOR, ENHANCEMENTS
     revision = REVISION, BUG FIXES
+
+    ; must also load a PreviousVersionProvider
+    [PreviousVersion::Changelog]
 
 =head1 DESCRIPTION
 
@@ -217,7 +221,8 @@ has previous_version => (
             $self->zilla->plugins_with('-YANICK::PreviousVersionProvider');
 
         $self->log_fatal( 
-            "at least one plugin with the role PreviousVersionProvider is required" 
+            "at least one plugin with the role PreviousVersionProvider",
+            "must be referenced in dist.ini"
         ) unless ref $plugins and @$plugins >= 1;
 
         for my $plugin ( @$plugins ) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -77,7 +77,7 @@ throws_ok
 $tzil = make_tzil( make_dist_ini( pvp => 0 ), make_changes('') );
 throws_ok
     { $tzil->build; }
-    qr/one plugin with the role PreviousVersionProvider is required/,
+    qr/PreviousVersionProvider must be referenced in dist\.ini/,
     'must throw correct error if no PreviousVersionProvider loaded';
 
 ### utility functions


### PR DESCRIPTION
In v0.1.0 of `Dist::Zilla::Plugin::NextVersion::Semantic`, the `before_release` method never runs because the plugin doesn't consume the `Dist::Zilla::Role::BeforeRelease` role.

This pull request includes a test for the problem and a fix, and resolves [[rt.cpan.org #84744]](https://rt.cpan.org/Ticket/Display.html?id=84744).

**Update:**  It seems that I haven't quite mastered pull requests, and some other commits for unrelated things have made it in as well.  This pull request now also addresses issues raised in [[rt.cpan.org #84359]](https://rt.cpan.org/Ticket/Display.html?id=84359).
