### PR TITLE
NextVersion::Semantic on new release

### DIFF
--- a/lib/Dist/Zilla/Plugin/NextVersion/Semantic.pm
+++ b/lib/Dist/Zilla/Plugin/NextVersion/Semantic.pm
@@ -256,7 +256,7 @@ use List::AllUtils qw/ first_index any /;
         my $previous = $self->previous_version;
 
         # initial version is special
-        unless ( $previous eq '0' ) {
+        unless ( $previous eq '0' || $previous eq '0.0.0' ) {
             my $regex = quotemeta $self->format;
             $regex =~ s/\\%0(\d+)d/(\\d{$1})/g;
             $regex =~ s/\\%(\d+)d/(\\d{1,$1})/g;


### PR DESCRIPTION
Hi,

When using NextVersion::Semantic on a new release it dies with `previous version '0.0.0' doesn't match format`, which is the version PreviousVersion::Changelog gives if no previous version is found.

This also checks for that version.

I'm not sure if it is best fixed here or in PreviousVersion::Changelog (returning `0` when missing version)?
