### PR TITLE
t/basic.t: Don't become broken when MAKEOPTS includes V=1

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for {{$dist->name}}
   [ API CHANGES ]
 
   [ BUG FIXES ]
+  - Don't let tests fail when V=1 is in MAKEOPTS for Gnu AutoTools "Verbose" mode
 
   [ DOCUMENTATION ]
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -6,6 +6,10 @@ use Test::Exception;
 
 use Test::DZil;
 
+# V=1 is common in MAKEOPTS for gnu autotools
+# to set "verbose mode"
+delete $ENV{V} if exists $ENV{V};
+
 my $changes = make_changes(<<'END_CHANGES');
     - got included in an awesome test suite
 END_CHANGES


### PR DESCRIPTION
Some people set MAKEOPTS to include V=1, in order to coax autotools
based makefiles into being more verbose.

But when that ENV var is used to direct perl ebuilds for Dzil things,
well, it unintentionally uses "1" as the *next version*, and so breaks
all code that isn't expecting that to happen.

Given its not the job of tests to tell people their system is weird, it
just makes the scope "normal" ( that is, defaulting V to be unset
internally )

Bug: https://bugs.gentoo.org/737308